### PR TITLE
feat(editor): add integration of code editor lib

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@apollo/client": "^3.11.10",
     "@hookform/resolvers": "^4.1.3",
+    "@monaco-editor/react": "^4.7.0",
     "@parcel/watcher": "^2.5.1",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -5375,8 +5375,6 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@types/aria-query@5.0.4': {}
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.27.0
@@ -5639,10 +5637,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  aria-query@5.3.0:
-    dependencies:
-      dequal: 2.0.3
-
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -5711,8 +5705,6 @@ snapshots:
   astral-regex@2.0.0: {}
 
   async-function@1.0.0: {}
-
-  asynckit@0.4.0: {}
 
   auto-bind@4.0.0: {}
 
@@ -5890,10 +5882,6 @@ snapshots:
 
   colorette@2.0.20: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   common-tags@1.8.2: {}
 
   concat-map@0.0.1: {}
@@ -6011,11 +5999,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  delayed-stream@1.0.0: {}
-
   dependency-graph@0.11.0: {}
-
-  dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
 
@@ -6064,8 +6048,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
-
-  entities@4.5.0: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -6406,13 +6388,6 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.2:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
-
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -6599,10 +6574,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -6732,8 +6703,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
-
-  is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -7013,15 +6982,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   mimic-fn@2.1.0: {}
-
-  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -7030,6 +6991,8 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
+
+  monaco-editor@0.52.2: {}
 
   ms@2.1.3: {}
 
@@ -7214,10 +7177,6 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
-  parse5@7.2.1:
-    dependencies:
-      entities: 4.5.0
-
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
@@ -7283,10 +7242,6 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
 
   punycode@2.3.1: {}
 
@@ -7358,11 +7313,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  redent@3.0.0:
-    dependencies:
-      indent-string: 4.0.0
-      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -7488,10 +7438,6 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
-
-  saxes@6.0.0:
-    dependencies:
-      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -7705,8 +7651,6 @@ snapshots:
 
   symbol-observable@4.0.0: {}
 
-  symbol-tree@3.2.4: {}
-
   sync-fetch@0.6.0-2:
     dependencies:
       node-fetch: 3.3.2
@@ -7895,11 +7839,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  url-parse@1.5.10:
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
 
   urlpattern-polyfill@10.0.0: {}
 

--- a/frontend/src/features/editor/components/EditorContainer.tsx
+++ b/frontend/src/features/editor/components/EditorContainer.tsx
@@ -1,0 +1,7 @@
+import Editor from '@monaco-editor/react';
+
+const EditorContainer = () => {
+    return <Editor defaultLanguage="javascript" theme='vs-dark' />;
+}
+
+export default EditorContainer;

--- a/frontend/src/shared/pages/HomePage.tsx
+++ b/frontend/src/shared/pages/HomePage.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from 'react'
-import UserProfile from '../views/UserProfile'
+import EditorContainer from '@/features/editor/components/EditorContainer'
 
 const HomePage = () => {
   return (
     <Suspense fallback={<p>Loading...</p>}>
-      <UserProfile />
+      <EditorContainer />
     </Suspense>
   )
 }

--- a/frontend/src/shared/views/Layout.tsx
+++ b/frontend/src/shared/views/Layout.tsx
@@ -4,7 +4,7 @@ import { Toaster } from '../components/ui/sonner'
 
 const Layout = () => {
   return (
-    <div className="m-auto p-4">
+    <div className="p-4 h-dvh grid grid-rows-[auto_1fr] gap-1">
       <NavBar />
       <main>
         <Outlet />

--- a/frontend/src/shared/views/UserProfile.tsx
+++ b/frontend/src/shared/views/UserProfile.tsx
@@ -1,9 +1,0 @@
-const UserProfile = () => {
-  return (
-    <div className="py-4">
-      <p>Hello CodeJamer</p>
-    </div>
-  )
-}
-
-export default UserProfile


### PR DESCRIPTION
## ✨ What’s new

- Integrated code editor library (Monaco).
- Added `<EditorContainer />` component.
- Updated `HomePage.tsx` and `Layout.tsx` accordingly.

## 🧪 How to test

- Go to the homepage.
- The editor should appear with basic functionality (typing, syntax highlighting, etc.).

## ❌ Removed

- Obsolete `UserProfile.tsx` view.